### PR TITLE
base container on ubuntu:trusty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /opt/dreamfactory
 #RUN composer require "predis/predis:~1.0"
 
 # install packages
+RUN composer update
 RUN composer install
 
 RUN php artisan dreamfactory:setup --no-app-key --db_driver=mysql --df_install=Docker


### PR DESCRIPTION
As per issue https://github.com/dreamfactorysoftware/df-docker/issues/16: Base container on `ubuntu:trusty`.

Other changes:

- run `chmod +x` on `docker-entrypoint.sh`, because on Windows the permissions get nuked.
- run `composer update` before running `composer install` I am very new to PHP and related tooling, so
  this may have issues that I'm unaware of, but it appeared to work fine on my machine.