### PR TITLE
Fixed entrypoint script so containers are reusable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ RUN php artisan dreamfactory:setup --no-app-key --db_driver=mysql --df_install=D
 # file based cache.  If you're using a mysql service, change db_driver to mysql
 #RUN php artisan dreamfactory:setup --no-app-key --db_driver=pgsql --cache_driver=redis --df_install="Docker(Bluemix)"
 
+# Uncomment this line and set your existing APP_KEY if you want to reuse existing DF database and configs
+# You also have to make sure that docker-entrypoint.sh is NEVER generating a new key.
+#RUN sed -i 's/APP_KEY=SomeRandomString/APP_KEY=foobar_baz/' .env
+
 RUN chown -R www-data:www-data /opt/dreamfactory
 
 ADD docker-entrypoint.sh /docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,18 @@ if [ -n "$DB_PORT_3306_TCP_ADDR" ]; then
   export DB_HOST=$DB_PORT_3306_TCP_ADDR
 fi
 
-(cd /opt/dreamfactory; grep -c "APP_KEY=SomeRandomString" .env > /dev/null && (echo "Generating APP_KEY"; php artisan key:generate))
+# generate AppKey on first run
+cd /opt/dreamfactory
+if [ ! -e .first_run_done ]; then
+  echo "Generating APP_KEY"
+  php artisan key:generate
+  touch .first_run_done
+fi
+
+# Make sure we're not confused by old, incompletely-shutdown httpd
+# context after restarting the container.  httpd won't start correctly
+# if it thinks it is already running. Same path as APACHE_RUN_DIR in /etc/apache2/envvars
+rm -rf /var/run/apache2/*
 
 #
 # start Apache


### PR DESCRIPTION
fixes #13 #11

After some digging I found the actual culprit to be the grep -c.. which made the script exit and therefore the entire container.

I also added cleaning the Apache PID file as seen in many popular Docker images using Apache

The other problem was the `APP_KEY` being regenerated when rebuilding the image which makes reusing the same external DB impossible. 
As there are different scenarios where this is not a problem, I made this optional and commented it out by default.