### PR TITLE
fix for php mongodb driver extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM ubuntu:latest
+FROM ubuntu:trusty
 
 MAINTAINER David Weiner<davidweiner@dreamfactory.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y \
-    git-core curl apache2 php5 php5-common php5-cli php5-curl php5-json php5-mcrypt php5-mysqlnd php5-pgsql php5-sqlite && \
+    git-core curl apache2 php5 php5-common php5-cli php5-curl php5-json php5-mcrypt php5-mysqlnd php5-pgsql php5-sqlite \
+    php-pear php5-dev openssl pkg-config libpcre3-dev && \
     rm -rf /var/lib/apt/lists/*
+
+RUN pecl install mongodb && echo "extension=mongodb.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 
 # install composer
 RUN curl -sS https://getcomposer.org/installer | php && \


### PR DESCRIPTION
fixes #16 #17 #19 

this PR fixes the composer dependency errors introduced with the latest df-mongo changes to the mongodb driver

It also includes the fix for the base image. PR #17 is against develop branch which is behind master