### PR TITLE
Make .env configs environment variable based

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,13 +43,10 @@ RUN php artisan dreamfactory:setup --no-app-key --db_driver=mysql --df_install=D
 # file based cache.  If you're using a mysql service, change db_driver to mysql
 #RUN php artisan dreamfactory:setup --no-app-key --db_driver=pgsql --cache_driver=redis --df_install="Docker(Bluemix)"
 
-# Uncomment this line and set your existing APP_KEY if you want to reuse existing DF database and configs
-# You also have to make sure that docker-entrypoint.sh is NEVER generating a new key.
-#RUN sed -i 's/APP_KEY=SomeRandomString/APP_KEY=foobar_baz/' .env
-
 RUN chown -R www-data:www-data /opt/dreamfactory
 
 ADD docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/apache2/access.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,6 @@ sed -i "s;%SERVERNAME%;${SERVERNAME:=dreamfactory.app};g" /etc/apache2/sites-ava
 if [ -n "$REDIS_HOST" ]; then
   sed -i "s/#REDIS_HOST=127.0.0.1/REDIS_HOST=$REDIS_HOST/" .env
   sed -i "s/#REDIS_DATABASE=/REDIS_DATABASE=$REDIS_DATABASE/" .env
-  sed -i "s/#REDIS_PASSWORD=/REDIS_PASSWORD=$REDIS_PASSWORD/" .env
   sed -i "s/CACHE_DRIVER=file/CACHE_DRIVER=redis/" .env
 fi
 if [ -n "$REDIS_PASSWORD" ]; then
@@ -29,12 +28,16 @@ if [ -n "$DB_PORT_3306_TCP_ADDR" ]; then
   export DB_HOST=$DB_PORT_3306_TCP_ADDR
 fi
 
-# generate AppKey on first run
-cd /opt/dreamfactory
-if [ ! -e .first_run_done ]; then
-  echo "Generating APP_KEY"
-  php artisan key:generate
-  touch .first_run_done
+# do we have an existing APP_KEY we should reuse ?
+if [ -n "$APP_KEY" ]; then
+  sed -i "s/APP_KEY=SomeRandomString/APP_KEY=$APP_KEY/" .env
+else
+  # generate AppKey on first run
+  if [ ! -e .first_run_done ]; then
+    echo "Generating APP_KEY"
+    php artisan key:generate
+    touch .first_run_done
+  fi
 fi
 
 # Make sure we're not confused by old, incompletely-shutdown httpd

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,8 +2,27 @@
 set -e
 
 # update site configuration
-# if no servername is provided use dreamfactory.local as default
+# if no servername is provided use dreamfactory.app as default
 sed -i "s;%SERVERNAME%;${SERVERNAME:=dreamfactory.app};g" /etc/apache2/sites-available/dreamfactory.conf
+
+# do we have configs for a Redis Cache ?
+if [ -n "$REDIS_HOST" ]; then
+  sed -i "s/#REDIS_HOST=127.0.0.1/REDIS_HOST=$REDIS_HOST/" .env
+  sed -i "s/#REDIS_DATABASE=/REDIS_DATABASE=$REDIS_DATABASE/" .env
+  sed -i "s/#REDIS_PASSWORD=/REDIS_PASSWORD=$REDIS_PASSWORD/" .env
+  sed -i "s/CACHE_DRIVER=file/CACHE_DRIVER=redis/" .env
+fi
+if [ -n "$REDIS_PASSWORD" ]; then
+  sed -i "s/#REDIS_PASSWORD=/REDIS_PASSWORD=$REDIS_PASSWORD/" .env
+fi
+
+# do we have configs for an external DB ?
+if [ -n "$DB_HOST" ]; then
+  sed -i "s/DB_HOST=localhost/DB_HOST=$DB_HOST/" .env
+  sed -i "s/DB_USERNAME=df_admin/DB_USERNAME=$DB_USERNAME/" .env
+  sed -i "s/DB_PASSWORD=df_admin/DB_PASSWORD=$DB_PASSWORD/" .env
+  sed -i "s/DB_DATABASE=dreamfactory/DB_DATABASE=$DB_DATABASE/" .env
+fi
 
 # check if we have a linked database container
 if [ -n "$DB_PORT_3306_TCP_ADDR" ]; then


### PR DESCRIPTION
This PR enables the df-docker image to be configurable via environment variables which makes it possible to use the same image for different installations/environments (prod, staging..) and for using an external MySQL db aswell as a linked mysql container.
And using Redis as cache or not. It doesnt matter, the image stays the same.

Its also very helpful to use it via docker-compose like so
```
DB_HOST=mysql.acme.com
DB_USERNAME=df_admin
DB_PASSWORD=foobar
DB_DATABASE=df2
REDIS_HOST=redis.acme.com
REDIS_DATABASE=0
APP_KEY=super_secret
```
or by passing the env vars via `docker run.... -e DB_HOST=mysql.acme.com etc..`
or using the image with a docker orchestrator like mesos/kubernetes/AWS ECS/etc

There are more configs (memcache..)  that could be set like this but as we dont need them, I havent added them. But my changes give everyone enough of an idea on how to add them easily.

If no APP_KEY is passed in, a new one is generated.

PS: I know there is `php artisan dreamfactory:setup` command which could be used instead of `sed` but "my approach" gives one better control over whats really going on in a container and a basic `dreamfactory:setup` run is already done in the Dockerfile = resulting image.