### PR TITLE
log dreamfactory.log to STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Go to 127.0.0.1 in your browser. It will take some time the first time. You will
 
 # Notes
 - You may have to use `sudo` for Docker commands depending on your setup.
+- By default, the container only sends apache error logs to STDOUT. If you also want to have dreamfactory.log, e.g. for forwarding via docker logging driver
+you can set environment variable `LOG_TO_STDOUT=true`
 
 # Configuration method 4 (build your own for IBM Bluemix)
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -60,6 +60,12 @@ done
 # if it thinks it is already running. Same path as APACHE_RUN_DIR in /etc/apache2/envvars
 rm -rf /var/run/apache2/*
 
+if [ -n "$LOG_TO_STDOUT" ]; then
+  echo "Also writing dreamfactory.log messages to STDOUT"
+  # we cannot ln the log to stdout like with apache logs, so we continuously tail it
+  tail --pid $$ -F /opt/dreamfactory/storage/logs/dreamfactory.log &
+fi
+
 #
 # start Apache
 exec /usr/sbin/apachectl -e info -DFOREGROUND


### PR DESCRIPTION
Its disabled by default. One needs to set env var `LOG_TO_STDOUT` for enabling.
Also updated README with a note

This comes in very handy if you are using any kind of docker logging driver for forwarding logs to a central logging system and you want dreamfactory.log application messages to also end up there