### PR TITLE
enabled mailing from DF 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y \
     git-core curl apache2 libapache2-mod-php7.0 php7.0-common php7.0-cli php7.0-curl php7.0-json php7.0-mcrypt php7.0-mysqlnd php7.0-pgsql php7.0-sqlite \
-    php-pear php7.0-dev php7.0-ldap php7.0-sybase php7.0-mbstring php7.0-zip php7.0-soap openssl pkg-config python nodejs python-pip zip
+    php-pear php7.0-dev php7.0-ldap php7.0-sybase php7.0-mbstring php7.0-zip php7.0-soap openssl pkg-config python nodejs python-pip zip ssmtp
 
 RUN rm -rf /var/lib/apt/lists/*
 
@@ -23,6 +23,8 @@ ADD v8/usr/lib/libv8* /usr/lib/
 ADD v8/usr/include /usr/include/
 ADD v8/usr/lib/php/20151012/v8js.so /usr/lib/php/20151012/v8js.so
 RUN echo "extension=v8js.so" > /etc/php/7.0/mods-available/v8js.ini && phpenmod v8js
+
+RUN echo 'sendmail_path = "/usr/sbin/ssmtp -t"' > /etc/php/7.0/cli/conf.d/mail.ini
 
 # install composer
 RUN curl -sS https://getcomposer.org/installer | php && \

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ container.  See the previous entry on how to view the values in VCAP SERVICES.
 # Environment options<a name="env-opts"></a>
 
 |Option|Description| required? |default
-|------|-----------|-|-|
+|------|-----------|---|---|
 |SERVERNAME|Domain for DF|no|dreamfactory.app
 |DB_HOST|Database Host|no|localhost
 |DB_USERNAME|Database User|no|df_admin

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker container for DreamFactory 2.2.x
 - See [https://docs.docker.com/compose/install](https://docs.docker.com/compose/install)
 
 ## Environment options
-- See [this table](#env-opts)
+- See [this table](#environment-options-1)
 
 # Configuration method 1 (use Docker Hub Image)
 
@@ -153,7 +153,7 @@ you are at a command prompt, run `echo $VCAP_SERVICES` which will display someth
 variable `BM_REDIS_SERVICE_KEY` and set it to the value present in VCAP_SERVICES environment variable provided to the 
 container.  See the previous entry on how to view the values in VCAP SERVICES.
 
-# Environment options<a name="env-opts"></a>
+# Environment options
 
 |Option|Description| required? |default
 |------|-----------|---|---|

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker container for DreamFactory 2.2.x
 - See [https://docs.docker.com/compose/install](https://docs.docker.com/compose/install)
 
 ## Environment options
-- See [this table](env-opts)
+- See [this table](#env-opts)
 
 # Configuration method 1 (use Docker Hub Image)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Docker container for DreamFactory 2.2.x
 ### Get Docker Compose (optional)
 - See [https://docs.docker.com/compose/install](https://docs.docker.com/compose/install)
 
+## Environment options
+- See [this table](env-opts)
+
 # Configuration method 1 (use Docker Hub Image)
 
 ## 1) Clone the df-docker repo
@@ -149,3 +152,24 @@ you are at a command prompt, run `echo $VCAP_SERVICES` which will display someth
 - If you use a service other than Redis Cloud, when starting the image, in step 7, you will have to add the environment
 variable `BM_REDIS_SERVICE_KEY` and set it to the value present in VCAP_SERVICES environment variable provided to the 
 container.  See the previous entry on how to view the values in VCAP SERVICES.
+
+# Environment options<a name="env-opts"></a>
+
+|Option|Description| required? |default
+|------|-----------|-|-|
+|SERVERNAME|Domain for DF|no|dreamfactory.app
+|DB_HOST|Database Host|no|localhost
+|DB_USERNAME|Database User|no|df_admin
+|DB_PASSWORD|Database Password|no|df_admin
+|DB_DATABASE|Database Name|no|dreamfactory
+|REDIS_HOST|Redis Cache Host|no|*uses file caching*
+|REDIS_DATABASE|Redis DB|only if REDIS_HOST set
+|REDIS_PORT|Redis Port|no|6379
+|REDIS_PASSWORD|Redis Password|no|*none used*
+|APP_KEY|Application Key|yes for immutability|*generates a key*
+|JWT_TTL|Login Token TTL|no|60
+|JWT_REFRESH_TTL|Login Token Refresh TTL|no|20160
+|ALLOW_FOREVER_SESSIONS|Allow refresh forever|no|false
+|LOG_TO_STDOUT|Forward log to STDOUT|no|*not forwarded*
+|SSMTP_mailhub|MX for mailing|yes if DF should mail|*no mailing capabilities*
+|SSMTP_XXXX|prefix options with SSMTP_|no|see the [man page](http://manpages.ubuntu.com/manpages/trusty/man5/ssmtp.conf.5.html)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -e
 
+# mail setup
+CONF=/etc/ssmtp/ssmtp.conf
+rm $CONF
+
+for E in $(env)
+do
+  if [ "$(echo $E | sed -e '/^SSMTP_/!d' )" ]
+  then
+    echo $E | sed -e 's/^SSMTP_//' >> $CONF
+  fi
+done
+
 # update site configuration
 # if no servername is provided use dreamfactory.app as default
 sed -i "s;%SERVERNAME%;${SERVERNAME:=dreamfactory.app};g" /etc/apache2/sites-available/dreamfactory.conf


### PR DESCRIPTION
containerized DF couldnt mail yet.

This is a more general problem with Docker containers and ssmtp probably the most common fix. and simple.
for more info see https://github.com/docker-library/php/issues/135 https://github.com/docker-library/wordpress/issues/30

For configuration you add environment variables like
```
SSMTP_mailhub=mx.acme.com
SSMTP_AuthUser=df
SSMTP_AuthPass=s3cret
SSMTP_UseTLS=YES
SSMTP_UseSTARTTLS=YES
```

All configuration options from here http://manpages.ubuntu.com/manpages/trusty/man5/ssmtp.conf.5.html are working, prfixed with `SSMTP_`

good to know: 
- use `SSMTP_rewriteDomain` to make the mails seem to come from a different of your domains
- you can change the FROM via /etc/ssmtp/revaliases if you need