### PR TITLE
Force rm of ssmtp.conf as it prevents container to restart properly

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # mail setup
 CONF=/etc/ssmtp/ssmtp.conf
-rm $CONF
+rm -f $CONF
 
 for E in $(env)
 do


### PR DESCRIPTION
After doing `docker-compose stop` and then `docker-compose start` then there I had the following error because I have no SSMTP environment variable and therefore ssmtp.conf was not created:
```
 rm: cannot remove '/etc/ssmtp/ssmtp.conf': No such file or directory
```
This error causes the container to exit.