### PR TITLE
Fix for Postgres support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ container.  See the previous entry on how to view the values in VCAP SERVICES.
 |DB_USERNAME|Database User|no|df_admin
 |DB_PASSWORD|Database Password|no|df_admin
 |DB_DATABASE|Database Name|no|dreamfactory
+|DB_PORT|Database Port|no|3306
 |REDIS_HOST|Redis Cache Host|no|*uses file caching*
 |REDIS_DATABASE|Redis DB|only if REDIS_HOST set
 |REDIS_PORT|Redis Port|no|6379

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,6 +36,11 @@ if [ -n "$REDIS_PASSWORD" ]; then
 fi
 
 # do we have configs for an external DB ?
+if [ -n "$DB_DRIVER" ]; then
+  echo "Setting DB_DRIVER"
+  sed -i "s/DB_CONNECTION=sqlite/DB_CONNECTION=$DB_DRIVER/" .env
+fi
+
 if [ -n "$DB_HOST" ]; then
   echo "Setting DB_HOST, DB_USERNAME, DB_PASSWORD, and DB_DATABASE"
   sed -i "s/DB_CONNECTION=sqlite/DB_CONNECTION=mysql/" .env
@@ -45,9 +50,9 @@ if [ -n "$DB_HOST" ]; then
   sed -i "s/DB_DATABASE=dreamfactory/DB_DATABASE=$DB_DATABASE/" .env
 fi
 
-if [ -n "$DB_DRIVER" ]; then
-  echo "Setting DB_DRIVER"
-  sed -i "s/DB_CONNECTION=sqlite/DB_CONNECTION=$DB_DRIVER/" .env
+if [ -n "$DB_PORT" ]; then
+  echo "Setting DB_PORT"
+  sed -i "s/DB_PORT=3306/DB_PORT=$DB_PORT/" .env
 fi
 
 # do we have an existing APP_KEY we should reuse ?


### PR DESCRIPTION
Using df-docker to deploy DF with Postgres does not appear to work currently.

Setting DB_DRIVER to a value other than mysql (e.g. pgsql) does not appear to work. This seems to be because the DB_HOST statement contains a specific reference to mysql. Moving the DB_DRIVER statement above the DB_HOST statement has the desired behaviour. I've not modified the DB_HOST because I could unexpectedly impact the current behaviour.

Adding support for setting DB_PORT was also required as Postgres uses port 5432 rather than MySQL's 3306

This fix should work for other databases too however I've only tested it with Postgres and MySQL.

Below is an example docker-compose.yml file for a Postgres deployment:
```yaml
version: '2'
services:
  web:
    environment:
      SERVERNAME: dreamfactory.local
      DB_HOST: pgsql
      DB_DRIVER: pgsql
      DB_USERNAME: df_admin
      DB_PASSWORD: df_admin
      DB_DATABASE: dreamfactory
      DB_PORT: 5432
      REDIS_HOST: redis
      REDIS_DATABASE: 0
      REDIS_PORT: 6379
      APP_KEY: ASDFIOWEQFASDKFASDFLJASDFJDKTWPG
    volumes:
      - df-storage:/opt/dreamfactory/storage
    build: .

  load-balancer:
    image: dockercloud/haproxy
    links:
        - web
    volumes:
        - /var/run/docker.sock:/var/run/docker.sock
    environment:
      BALANCE: roundrobin
    ports:
        - "80:80"
  pgsql:
    environment:
      POSTGRES_DB: dreamfactory
      POSTGRES_USER: df_admin
      POSTGRES_PASSWORD: df_admin
    image: postgres

  redis:
    image: redis

volumes:
  df-storage:
    driver: local
```