### PR TITLE
replaced sed delimiter with non valid base64 characters

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -68,7 +68,7 @@ fi
 # do we have an existing APP_KEY we should reuse ?
 if [ -n "$APP_KEY" ]; then
   echo "Setting APP_KEY=$APP_KEY from environment"
-  sed -i "s/APP_KEY=/APP_KEY=$APP_KEY/" .env
+  sed -i "s@APP_KEY=@APP_KEY=$APP_KEY@" .env
 else
   # generate AppKey on first run
   if [ ! -e .first_run_done ]; then


### PR DESCRIPTION
Laravel APP_KEY values are base64_encode strings. In base64 `/` is a valid output character. Therefore, if your your app key has a `/` in it, this sed command will fail and the container will not run properly, as it uses `/` for the delimiter. Replaced the `/` with `@` as it is not a valid base64 output character and should not conflict with valid keys.