### PR TITLE
mysql docker image must be fixed to 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you don't want to use docker-compose you can build the images yourself.
 `docker build -t dreamfactory .`  
 
 ## 3) Ensure that the database container is created and running
-`docker run -d --name df-mysql -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_DATABASE=dreamfactory" -e "MYSQL_USER=df_admin" -e "MYSQL_PASSWORD=df_admin" mysql`
+`docker run -d --name df-mysql -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_DATABASE=dreamfactory" -e "MYSQL_USER=df_admin" -e "MYSQL_PASSWORD=df_admin" mysql:5.7`
 
 ## 4) Ensure that the redis container is created and running
 `docker run -d --name df-redis redis`
@@ -183,7 +183,7 @@ For this purpose we are assuming that you have already built your DreamFactory i
 
 Start your MySQL container.
 
-`docker run -d --name df-mysql -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_DATABASE=dreamfactory" -e "MYSQL_USER=df_admin" -e "MYSQL_PASSWORD=df_admin" mysql`
+`docker run -d --name df-mysql -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_DATABASE=dreamfactory" -e "MYSQL_USER=df_admin" -e "MYSQL_PASSWORD=df_admin" mysql:5.7`
 
 Start your Redis container.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       MYSQL_DATABASE: dreamfactory
       MYSQL_USER: df_admin
       MYSQL_PASSWORD: df_admin
-    image: mysql
+    image: mysql:5.7
 
   redis:
     image: redis


### PR DESCRIPTION
If we don't specify the mysql image version it will default to latest tag which at this time is version 5.8 and has some incompatible changes.

Basically this is related to changes in the default authentication plugin and until we update the Laravel framework configuration, the dreamfactory web app will fail the installation process with an error of 
**"The server requested authentication method unknown to the client"**

So, fixing the mysql version to 5.7, is the quickest change to get these docker containers working.

Please see https://github.com/laravel/framework/issues/19522 and https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-4.html for more details.