### PR TITLE
Fixed v8js make error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ WORKDIR /v8
 RUN cp -R ubuntu_16.04/PHP7.1/* /opt/v8 && \
     git clone https://github.com/phpv8/v8js.git /v8js
 WORKDIR /v8js
-RUN phpize && \
+RUN git checkout 1.3.6 && \
+    git pull origin 1.3.6 && \
+    phpize && \
     ./configure --with-v8js=/opt/v8 && \
     make && make install && \
     echo "extension=v8js.so" > /etc/php/7.1/mods-available/v8js.ini && \


### PR DESCRIPTION
The error itself:
<img width="1310" alt="download" src="https://user-images.githubusercontent.com/2478448/48415559-60151c00-e756-11e8-93d3-bdfb6d00afcb.png">


A solution was taken from official manual: http://wiki.dreamfactory.com/DreamFactory/APT/Ubuntu_16.04/Modules/v8js