### PR TITLE
Improve fpm-php configs to prevent memory leakage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,7 @@ RUN ln -s /etc/nginx/sites-available/dreamfactory.conf /etc/nginx/sites-enabled/
     sed -i "s/pm.start_servers = 2/pm.start_servers = 150/" /etc/php/7.1/fpm/pool.d/www.conf && \
     sed -i "s/pm.min_spare_servers = 1/pm.min_spare_servers = 100/" /etc/php/7.1/fpm/pool.d/www.conf && \
     sed -i "s/pm.max_spare_servers = 3/pm.max_spare_servers = 200/" /etc/php/7.1/fpm/pool.d/www.conf && \
+    sed -i "s/pm = dynamic/pm = ondemand/" /etc/php/7.1/fpm/pool.d/www.conf && \
     sed -i "s/worker_connections 768;/worker_connections 2048;/" /etc/nginx/nginx.conf && \
     sed -i "s/keepalive_timeout 65;/keepalive_timeout 10;/" /etc/nginx/nginx.conf
 


### PR DESCRIPTION
Otherwise each time the page is reloaded in the browser the memory is consumed. Around 10Mb after each page reload.