### PR TITLE
Add HTTPS header

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
   web:
     environment:
       SERVERNAME: dreamfactory.local
+#      HTTPS_HEADER: "on"
       DB_DRIVER: mysql
       DB_HOST: mysql
       DB_USERNAME: df_admin

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,6 +17,9 @@ done
 # if no servername is provided use dreamfactory.app as default
 sed -i "s;%SERVERNAME%;${SERVERNAME:=dreamfactory.app};g" /etc/nginx/sites-available/dreamfactory.conf
 
+# Allow Laravel to accept requests from top level reverse proxy if it is using HTTPS. "off" by default.
+sed -i "s;%HTTPS_HEADER%;${HTTPS_HEADER:=off};g" /etc/nginx/sites-available/dreamfactory.conf
+
 # do we have configs for a cache ?
 if [ -n "$CACHE_DRIVER" ]; then
   echo "Setting CACHE_DRIVER, CACHE_HOST, CACHE_DATABASE"
@@ -149,7 +152,6 @@ fi
 if [ -n "$REDIS_PORT" ]; then
   echo "REDIS_PORT=$REDIS_PORT" >> .env
 fi
-
 
 # start php7.1-fpm
 service php7.1-fpm start

--- a/dreamfactory.conf
+++ b/dreamfactory.conf
@@ -43,6 +43,7 @@ server {
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param HTTPS %HTTPS_HEADER%;
         fastcgi_connect_timeout 60;
         fastcgi_send_timeout 180;
         fastcgi_read_timeout 180;


### PR DESCRIPTION
If there is no HTTPS=on header then Laravel app could rise **Not allowed in CORS policy** error.
This issue can happen in case the Docker deployment of DF is running behind another reverse proxy which handles HTTPS. 