### PR TITLE
Ensure MCP daemon node_modules are installed before startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,12 @@ RUN composer clear-cache && \
     chown -R www-data:www-data /opt/dreamfactory && \
     rm /etc/nginx/sites-enabled/default
 
+# Install MCP daemon Node.js dependencies (if the daemon package is present)
+RUN if [ -f /opt/dreamfactory/vendor/dreamfactory/df-mcp-server/daemon/package.json ]; then \
+        cd /opt/dreamfactory/vendor/dreamfactory/df-mcp-server/daemon && \
+        npm install --production; \
+    fi
+
 # Replace YOUR_LICENSE_KEY with your license key, keeping the comma at the end
 #RUN sed -i "s,\#DF_REGISTER_CONTACT=,DF_LICENSE_KEY=YOUR_LICENSE_KEY," /opt/dreamfactory/.env
 


### PR DESCRIPTION
## Summary
- Adds `npm install --production` to the Dockerfile during image build so MCP daemon dependencies are baked into the image
- Adds a runtime safety check in `docker-entrypoint.sh` to install `node_modules` if missing (handles cases where vendor gets updated after build)
- Adds better error handling: warns if `ENABLE_MCP_DAEMON` is set but the daemon package isn't present

## Context
The MCP daemon's `start-daemon.sh` script skips `npm install` when `dist/server.js` exists (which is committed to the repo), causing the daemon to fail at runtime without `node_modules`. This was the root cause of the daemon not starting after container restarts.

Supersedes #121 (which was based on develop and had merge conflicts with master).

## Test plan
- [ ] Build image and verify `node_modules` exist in `/opt/dreamfactory/vendor/dreamfactory/df-mcp-server/daemon/`
- [ ] Start container with `ENABLE_MCP_DAEMON=true` and verify daemon starts
- [ ] Restart container and verify daemon starts again
- [ ] Start container without `ENABLE_MCP_DAEMON` and verify no daemon warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)