### PR TITLE
release: PHP 8.3 → 8.5 for Laravel 13 / PHP 8.5

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,11 +16,11 @@ env | awk -F'\n' '/^SSMTP_/ { print substr($1, 7) }' > "$CONF"
 
 # Configure NGINX and www.conf
 ln -s /etc/nginx/sites-available/dreamfactory.conf /etc/nginx/sites-enabled/dreamfactory.conf && \
-sed -i "s/pm.max_children = 5/pm.max_children = 5000/" /etc/php/8.3/fpm/pool.d/www.conf && \
-sed -i "s/pm.start_servers = 2/pm.start_servers = 150/" /etc/php/8.3/fpm/pool.d/www.conf && \
-sed -i "s/pm.min_spare_servers = 1/pm.min_spare_servers = 100/" /etc/php/8.3/fpm/pool.d/www.conf && \
-sed -i "s/pm.max_spare_servers = 3/pm.max_spare_servers = 200/" /etc/php/8.3/fpm/pool.d/www.conf && \
-sed -i "s/pm = dynamic/pm = ondemand/" /etc/php/8.3/fpm/pool.d/www.conf && \
+sed -i "s/pm.max_children = 5/pm.max_children = 5000/" /etc/php/8.5/fpm/pool.d/www.conf && \
+sed -i "s/pm.start_servers = 2/pm.start_servers = 150/" /etc/php/8.5/fpm/pool.d/www.conf && \
+sed -i "s/pm.min_spare_servers = 1/pm.min_spare_servers = 100/" /etc/php/8.5/fpm/pool.d/www.conf && \
+sed -i "s/pm.max_spare_servers = 3/pm.max_spare_servers = 200/" /etc/php/8.5/fpm/pool.d/www.conf && \
+sed -i "s/pm = dynamic/pm = ondemand/" /etc/php/8.5/fpm/pool.d/www.conf && \
 sed -i "s/worker_connections 768;/worker_connections 2048;/" /etc/nginx/nginx.conf && \
 sed -i "s/keepalive_timeout 65;/keepalive_timeout 10;/" /etc/nginx/nginx.conf
 sed -i 's/DF_INSTALL=.*/DF_INSTALL=Docker/' .env
@@ -232,8 +232,8 @@ if [ -n "$ENABLE_MCP_DAEMON" ]; then
   fi
 fi
 
-# start php8.3-fpm
-service php8.3-fpm start
+# start php8.5-fpm
+service php8.5-fpm start
 
 # start cron service for df-scheduler
 service cron start

--- a/dreamfactory.conf
+++ b/dreamfactory.conf
@@ -1,5 +1,5 @@
 upstream php_handler {
-    server unix:/var/run/php/php8.3-fpm.sock;
+    server unix:/var/run/php/php8.5-fpm.sock;
     #server 127.0.0.1:9000 backup;
 }
 


### PR DESCRIPTION
## Release: Laravel 13 / PHP 8.5

Part of the **31-package L13 / PHP 8.5 release cohort** (sibling PRs in df-core, df-system, df-database, df-sqldb, df-admin-interface, etc).

### Scope of THIS PR
Container path bumps required for the new stack:
- `docker-entrypoint.sh` — `/etc/php/8.3/fpm/pool.d/www.conf` → `/etc/php/8.5/...`
- `docker-entrypoint.sh` — `service php8.3-fpm start` → `php8.5-fpm`
- `dreamfactory.conf` — `unix:/var/run/php/php8.3-fpm.sock` → `php8.5-fpm.sock`

No logic changes. No cache-permission changes — `chown -R www-data:www-data storage/ bootstrap/cache/` on lines 151-152 already runs as root **after** all root-side artisan calls (`migrate:--seed`, `df:setup`, `cache:clear`, `config:clear`) and **before** `php-fpm` starts on line 218, so php-fpm always inherits writable cache subdirs. Verified against the L13/PHP 8.5 release bundle (`df-l13-php85:test`) smoke battery — no permission denied errors.

### Deferred to follow-up
The `FROM dreamfactorysoftware/df-base-img:v7` line in `Dockerfile` is intentionally **not** bumped in this PR — that tag is published by **[df-docker-base PR #18](https://github.com/dreamfactorysoftware/df-docker-base/pull/18)** (PHP 8.5 base image), which is still in review.

**This PR is Draft until that base image is tagged and published.** Once PR #18 lands and the new tag is on Docker Hub, the FROM line will be updated in a follow-up commit on this branch before flipping out of Draft.

### Verification
Built and smoke-tested inside `df-l13-php85:test` (which uses a locally-built PHP 8.5 base image equivalent to what PR #18 will publish):
- ✅ PHP 8.5.5 / Zend 4.5.5 boots
- ✅ Laravel 13.11.2 detected via `artisan --version`
- ✅ `php artisan migrate --force` exits 0
- ✅ `php artisan df:setup --force` succeeds
- ✅ POST `/api/v2/system/admin/session` returns JWT
- ✅ Service-type registry lists 60+ types (all df-* ServiceProviders loaded)
- ✅ Postgres service create + schema introspection + CRUD all green
- ✅ OpenAPI generation works (30+ paths)
- ✅ df-mcp-server daemon starts under supervisord

### Cohort
Merge order:
1. **df-docker-base [#18](https://github.com/dreamfactorysoftware/df-docker-base/pull/18)** (base image — release-blocking)
2. Foundation: df-core, df-system, df-user, df-database
3. SQL connectors (df-sqldb, df-sqlsrv, df-snowflake, df-databricks, df-dremio, df-hana, df-trino)
4. NoSQL / Auth / Services / AI tiers
5. df-admin-interface
6. Host app `dreamfactory/dreamfactory` (if applicable)
7. **THIS PR (df-docker)** — last, since it depends on every sibling tag being available
